### PR TITLE
k8s host logic should prefer user-defined variable

### DIFF
--- a/src/datasources/kubernetes.datasource.ts
+++ b/src/datasources/kubernetes.datasource.ts
@@ -18,11 +18,7 @@ export class KubernetesDataSource implements LifeCycleObserver {
   constructor() {
     try {
 
-      if (process.env.KUBERNETES_SERVICE_HOST) {
-        logger.info('Using kubernetes cluster configuration');
-        this._k8sClient = new Client({ version: '1.13' });
-
-      } else if (APPLICATION_CONFIG().kubernetes.host) {
+      if (APPLICATION_CONFIG().kubernetes.host) {
         logger.info('Using defined variables for kubernetes configuration');
         const kubeconfig = new KubeConfig();
         const k8Sconfig = new K8SConfigCreator().getConfig();
@@ -30,6 +26,10 @@ export class KubernetesDataSource implements LifeCycleObserver {
         kubeconfig.loadFromString(JSON.stringify(k8Sconfig));
         const backend = new Request({ kubeconfig });
         this._k8sClient = new Client({ backend, version: '1.13' });
+
+      } else if (process.env.KUBERNETES_SERVICE_HOST) {
+        logger.info('Using kubernetes cluster configuration');
+        this._k8sClient = new Client({ version: '1.13' });
 
       } else {
         throw new LoggedError('Did not manage to define kubernetes configuration');


### PR DESCRIPTION
`KUBERNETES_SERVICE_HOST` will always [1] be set in a typical
k8s environment, and so the initial `if` logic always takes
precedence, and doesn't allow the consideration of the `else if`,
in this case the variable `CLOUD_PROVIDER_K8S_KUBERNETES_HOST`.
We switch the logic around to make `KUBERNETES_SERVICE_HOST` be
the fallthrough choice, before erroring-out.

This supports environments where the `panosc-instances` namespace,
and thus the pods, are not running on the same k8s environment as
the portal microservices.

[1] https://github.com/hashicorp/vault/blob/master/serviceregistration/kubernetes/client/config.go#L13